### PR TITLE
Fix typo in GitHub URL

### DIFF
--- a/src/components/layout/BaseNavigation.astro
+++ b/src/components/layout/BaseNavigation.astro
@@ -7,7 +7,7 @@ const navigationItems = [
 const socialIcons = [
   {
     name: 'GitHub',
-    url: 'https://github.com/jennjunodl',
+    url: 'https://github.com/jennjunod',
     icon: 'i-uil-github',
   },
   {


### PR DESCRIPTION
Noticed your GitHub nav link was pointing to `jennjunodl` on GitHub (with an extra `L` on the end)